### PR TITLE
Fix using GetProcAddress before loading the library

### DIFF
--- a/math_test.c
+++ b/math_test.c
@@ -20,13 +20,6 @@ int main(int argc, char *argv[]) {
     FILE *out;
     HMODULE hLib;
 
-    asinf_func my_asinf = (asinf_func)GetProcAddress(hLib, "asinf");
-    if (!my_asinf) {
-        printf("Failed to get address of asin\n");
-        FreeLibrary(hLib);
-        return 1;
-    }
-
     int native = 0;
     const char *filename = "math_test_out.bin";
     if (argc > 1) {
@@ -63,6 +56,13 @@ int main(int argc, char *argv[]) {
 
     if (!hLib) {
         printf("Failed to load ucrtbase.dll\n");
+        return 1;
+    }
+    
+    asinf_func my_asinf = (asinf_func)GetProcAddress(hLib, "asinf");
+    if (!my_asinf) {
+        printf("Failed to get address of asin\n");
+        FreeLibrary(hLib);
         return 1;
     }
 


### PR DESCRIPTION
Hi, I just found out your repository after spending a good amount of hours on this very problem this weekend.

How about we try to cooperate a bit on it?

I tried to run your scripts and had to fix this issue, I am not sure how you could have missed it, unless you had your `.bin` already generated and the python script did not launch the script.

As for my efforts, I approached the problem from the opposite direction, trying to understand how ucrtbase.dll was structured by disassembling it (such reverse engineering approaches are legal where I am).

I then tried to replicate the output difference (without much success). 

I initially focused more on the cosh/sinh/cos/sin/_CIcos/_CIsin functions, though I came back to sinc trying to replicate the blogpost (which is how I landed here... the original branch was deleted).

As an aside, I was trying to replicate by letting Wine do the loading and compiling with:
```shell
i686-w64-mingw32-gcc -mcrtdll=ucrtbase -o cos_mingw cos.c
```

May I suggest using the MIT license if possible? It may be a better fit for this kind of project, and as far as I understand, Wine uses Musl's math implementation (MIT-licensed).